### PR TITLE
Update REST-fetch's stack and add Param Siddharth as a mentor

### DIFF
--- a/resource/2020/data_project_list.js
+++ b/resource/2020/data_project_list.js
@@ -2134,7 +2134,7 @@ const project_list = {
       project_description:
         "A community-owned REST API service for testers and developers. Fetch provides REST API endpoints for different types of placeholders, which can be easily used during testing and development without the need for creating sample data manually. It aims to create a free-for-all REST API service that is open-sourced so that developers can have the ease of making feature requests for a new end-point, or report a security bug. The code should be explicit and easy to contribute to for beginners with no or less apparent knowledge of REST APIs. The standalone API endpoints should be easy to use during development, with minimal setup effort.",
       project_video_link: "https://youtu.be/iafIbG0QB3w",
-      technology_used: "NodeJS, MongoBD, REST API, TypeScript, JavaScript, CI/CD, ReactJS",
+      technology_used: "NodeJS, MongoDB, REST API, TypeScript, JavaScript, CI/CD, Docker, ReactJS",
       repo_fullname: "adityabisoi/REST-fetch",
       // project_slack_channel: "proj_mentorfix",
       github: "https://github.com/adityabisoi/REST-fetch",
@@ -2157,6 +2157,11 @@ const project_list = {
         //   github: "https://github.com/laveesh",
            email: "shauryaag14@gmail.com",
         //   slackId: "UU0PYRJ3V",
+         },
+         {
+          name: "Param Siddharth",
+        //   github: "https://github.com/paramsiddharth",
+           email: "contact@paramsid.com",
          },
       ],
     },


### PR DESCRIPTION
# Update REST-fetch's stack and add Param Siddharth as a mentor
This PR contains updates to the REST-fetch project as communicated to @salil-naik by me. All changes were made in `resource/2020/data_project_list.js`.

## Summary
The following summarizes the updates in this PR:
- MongoDB was misspelt as MongoBD. Hence, when looking up MongoDB, REST-fetch didn't show up. That has been fixed.
- The mentor-list doesn't mention Param Siddharth. A new entry with the corresponding [e-mail address](mailto:contact@paramsid.com) has been added.
- The project technical stack involves the use of Docker for containerizing the application with a MongoDB server image in the back-end, so Docker has been included in the technical stack.

## Differences
| Before | Now |
| :-: | :-: |
| ![image](https://user-images.githubusercontent.com/30315706/113145798-85822200-924c-11eb-8817-f612aa16474c.png) | ![image](https://user-images.githubusercontent.com/30315706/113145922-a9ddfe80-924c-11eb-9409-85935b7158bb.png) |
| ![image](https://user-images.githubusercontent.com/30315706/113145990-c417dc80-924c-11eb-8a79-98c598d68238.png) | ![image](https://user-images.githubusercontent.com/30315706/113145967-b9f5de00-924c-11eb-9e03-d4ba2416163e.png) |